### PR TITLE
Add parent error class that inherits from StandardError instead of Exception

### DIFF
--- a/lib/smarty_streets/request.rb
+++ b/lib/smarty_streets/request.rb
@@ -1,10 +1,11 @@
 module SmartyStreets
   class Request
-    class InvalidCredentials < Exception; end
-    class MalformedData < Exception; end
-    class PaymentRequired < Exception; end
-    class NoValidCandidates < Exception; end
-    class RemoteServerError < Exception; end
+    class RequestError < StandardError; end
+    class InvalidCredentials < RequestError; end
+    class MalformedData < RequestError; end
+    class PaymentRequired < RequestError; end
+    class NoValidCandidates < RequestError; end
+    class RemoteServerError < RequestError; end
 
     attr_accessor :location
 


### PR DESCRIPTION
By default Ruby's `rescue` without specifiying a specific Error class
will rescue `StandardError`s, which means that SmartyStreets errors will
fall through most `rescue` calls and may incidentally cause developers
to catch the `Exception` class which is bad practice.

http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby