### PR TITLE
Add match type

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ SmartyStreets.configure do |c|
   c.auth_id = 'MY-AUTH-ID'
   c.auth_token = 'MY-AUTH-TOKEN'
   c.candidates = 5
+  c.match = 'strict'
 end
 
 locations = SmartyStreets.standardize do |location|

--- a/lib/smarty_streets.rb
+++ b/lib/smarty_streets.rb
@@ -16,6 +16,7 @@ module SmartyStreets
     #     config.auth_id = 'AUTHID'
     #     config.auth_token = 'AUTHTOKEN'
     #     config.candidates = 1
+    #     config.match = 'strict'
     #   end
     def configure
       self.configuration = Configuration.new

--- a/lib/smarty_streets/configuration.rb
+++ b/lib/smarty_streets/configuration.rb
@@ -12,9 +12,14 @@ module SmartyStreets
     # Number of candidates to provide when making a request.
     attr_accessor :candidates
 
+    # Match output strategy to be employed for this lookup. Valid values are: 'strict', 'range', 'invalid'
+    # View https://smartystreets.com/docs/cloud/us-street-api#input-fields for more information
+    attr_accessor :match
+
     def initialize
       @api_url = 'api.smartystreets.com'
       @candidates = 1
+      @match = 'strict'
     end
   end
 end

--- a/lib/smarty_streets/location.rb
+++ b/lib/smarty_streets/location.rb
@@ -6,6 +6,7 @@ module SmartyStreets
     attr_accessor :city, :state, :zipcode
     attr_accessor :lastline, :addressee, :urbanization
     attr_accessor :candidates
+    attr_accessor :match
 
     # Response only fields
     attr_accessor :input_index, :candidate_index

--- a/lib/smarty_streets/request.rb
+++ b/lib/smarty_streets/request.rb
@@ -58,6 +58,7 @@ module SmartyStreets
         lastline: location.lastline,
         addressee: location.addressee,
         urbanization: location.urbanization,
+        match: location.match,
         candidates: location.candidates || SmartyStreets.configuration.candidates,
         "auth-id" => SmartyStreets.configuration.auth_id,
         "auth-token" => SmartyStreets.configuration.auth_token

--- a/lib/smarty_streets/request.rb
+++ b/lib/smarty_streets/request.rb
@@ -58,7 +58,7 @@ module SmartyStreets
         lastline: location.lastline,
         addressee: location.addressee,
         urbanization: location.urbanization,
-        match: location.match,
+        match: location.match  || 'strict',
         candidates: location.candidates || SmartyStreets.configuration.candidates,
         "auth-id" => SmartyStreets.configuration.auth_id,
         "auth-token" => SmartyStreets.configuration.auth_token

--- a/lib/smarty_streets/request.rb
+++ b/lib/smarty_streets/request.rb
@@ -38,6 +38,7 @@ module SmartyStreets
         location.components             = l['components']
         location.metadata               = l['metadata']
         location.analysis               = l['analysis']
+        location.match                  = l['match']
         location
       end
     end
@@ -58,7 +59,7 @@ module SmartyStreets
         lastline: location.lastline,
         addressee: location.addressee,
         urbanization: location.urbanization,
-        match: location.match  || 'strict',
+        match: location.match || SmartyStreets.configuration.match,
         candidates: location.candidates || SmartyStreets.configuration.candidates,
         "auth-id" => SmartyStreets.configuration.auth_id,
         "auth-token" => SmartyStreets.configuration.auth_token

--- a/lib/smarty_streets/version.rb
+++ b/lib/smarty_streets/version.rb
@@ -1,3 +1,3 @@
 module SmartyStreets
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end


### PR DESCRIPTION
Added the "match" parameter which allows Addresses that are not valid with USPS to still return standardized addresses back.  Use case would be validation an address that does not accept mail delivery, but is a valid physical address.  Reference https://smartystreets.com/docs/cloud/us-street-api#input-fields